### PR TITLE
Update code to fit MSVC and Win32

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,7 @@
 @echo off
 
 set incl=%cd%\incl
-set opts=-FC -GR- -EHsc -nologo -Zi -Od -I"%incl%"
+set opts=-FC -GR- -EHsc -nologo -Zi -Od -std:c++latest -I"%incl%"
 set code=%cd%\src
 set link_dir=%cd%\lib
 set link_opts=opengl32.lib User32.lib Gdi32.lib %link_dir%\glew32.lib -SUBSYSTEM:WINDOWS

--- a/src/OpenSolomonsKey.cpp
+++ b/src/OpenSolomonsKey.cpp
@@ -478,7 +478,7 @@ cb_render(InputState istate, float dt)
                     iabs(diff.y) > 0)
                 {
                     is_on_air = false;
-                    player.velocity.y == 0;
+                    // player.velocity.y == 0;
                 }
                 else if (j == 0 && 
                          player.velocity.y < 0)

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -17,7 +17,8 @@ struct RESTilemap
 enum E_TILEMAPS { ALL_TILEMAPS TILEMAP_COUNT };
 
 #undef DEF_TILEMAP
-#define DEF_TILEMAP(name, path, rows, cols) [TILEMAP_##name] = {path, rows, cols},
+// #define DEF_TILEMAP(name, path, rows, cols) [TILEMAP_##name] = {path, rows, cols},
+#define DEF_TILEMAP(name, path, rows, cols) {path, rows, cols},
 
 #define GET_TILEMAP_TEXTURE(name) g_tilemap_textures[TILEMAP_##name]
 global GLTilemapTexture g_tilemap_textures[TILEMAP_COUNT];


### PR DESCRIPTION
Win32 blocks the thread when moving/resizing window by default. There are no complete solutions, so we just hack it to ignore update calls
(i.e delta time)