### PR TITLE
Audio rework

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,13 +3,13 @@
 TIMEFORMAT=%R
 
 code="$PWD/src/"
-opts="-lGL -lGLU -lX11 -lpthread -no-pie -Wno-write-strings -I$code/../"
+opts="-lGL -lGLU -lX11 -pthread -no-pie -Wno-write-strings -I$code/../"
 opt_debug="-g -ggdb -O0"
 opt_release="-O3 -DNDEBUG"
 cd build > /dev/null
 
 # Debug
-time g++ $opts $opt_debug $code/x11_OpenSolomonsKey.cpp -lasound -ljack /home/miked/Desktop/portaudio/lib/.libs/libportaudio.a -o solomons_key
+time g++ $opts $opt_debug $code/x11_OpenSolomonsKey.cpp -lasound -o solomons_key
 
 # Release
 #time g++ $opts $opt_release $code/x11_OpenSolomonsKey.cpp -lasound -ljack /home/miked/Desktop/portaudio/lib/.libs/libportaudio.a -o solomons_key

--- a/src/OpenSolomonsKey.cpp
+++ b/src/OpenSolomonsKey.cpp
@@ -386,7 +386,6 @@ cb_render(InputState istate, u64 audio_sample_count, float dt)
     if (dt > 0.13f) dt = 0.13f;
     
     scene_update(&istate, dt);
-    audio_update(&istate, audio_sample_count);
     
     // NOTE(miked): testing an effect
     if (GET_KEYPRESS(m_pressed))

--- a/src/OpenSolomonsKey.h
+++ b/src/OpenSolomonsKey.h
@@ -106,6 +106,7 @@ platform_load_entire_file(const char* path)
 #define AUDIO_BYTESPERSAMPLE ((AUDIO_BPS / 8) * AUDIO_CHANNELS)
 #define AUDIO_FRAMES 1024
 #define AUDIO_BUFFER_SIZE (AUDIO_SAMPLERATE * AUDIO_BYTESPERSAMPLE)
+//#define AUDIO_BUFFER_SIZE 1000 
 #define AUDIO_MAX_SOUNDS 32
 
 struct RESSound
@@ -138,8 +139,8 @@ global struct
     
     Sound all_sounds[AUDIO_MAX_SOUNDS];
     i32 all_sounds_size = 0;
-    //float volume = 0.5f;
-    float volume = 0.0f;
+    float volume = 0.5f;
+    //float volume = 0.0f;
     
     u8 buffer[AUDIO_BUFFER_SIZE] = {};
 } g_audio;

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -144,6 +144,7 @@ internal void audio_play_sound(const RESSound* resound, b32 looping = false, Sou
     if (g_audio.all_sounds_size >= AUDIO_MAX_SOUNDS)
         return;
     
+    
     Sound new_sound = 
     {
         .max_counter = resound->num_samples,
@@ -153,6 +154,7 @@ internal void audio_play_sound(const RESSound* resound, b32 looping = false, Sou
     };
     
     g_audio.all_sounds[g_audio.all_sounds_size++] = new_sound;
+    
 }
 
 internal void audio_toggle_playing(SoundType type)
@@ -202,7 +204,6 @@ internal void audio_update_all_sounds()
                     previous++;
                 }
                 
-                
             }
             
         }
@@ -214,8 +215,7 @@ audio_update(const InputState* const istate, u64 samples_to_write)
 {
     
     i16* out = (i16*)g_audio.buffer;
-    audio_update_all_sounds();
-    //printf("sz %d\n",g_audio.all_sounds_size );
+    //audio_update_all_sounds();
     
     memset(g_audio.buffer, 0, AUDIO_BUFFER_SIZE);
     for (u32 i = 0; i < samples_to_write; i += 1)

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -164,7 +164,7 @@ internal void load_tilemap_textures()
     
     for (u32 i = 0 ;i < TILEMAP_COUNT; ++i)
     {
-        printf("loading tilemap: %s...\n",RES_TILEMAPS[i].name);
+        inform("loading tilemap: %s...",RES_TILEMAPS[i].name);
         data = load_image_as_rgba_pixels(
             RES_TILEMAPS[i].name,
             &width, &height, &bpp);

--- a/src/win32_OpenSolomonsKey.cpp
+++ b/src/win32_OpenSolomonsKey.cpp
@@ -1,8 +1,7 @@
-/* NOTE(miked):
-Ok, so we're gonna have to do audio on a separate thread anyways
-*/
+/* win32_OpenSolomonsKey.cpp
+ Michael Dodis, All rights reserved.
+ */
 #define OSK_PLATFORM_WIN32
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -10,7 +9,6 @@ Ok, so we're gonna have to do audio on a separate thread anyways
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <GL/GL.h>
-#include <portaudio.h>
 
 #define OSK_PLATFORM_WIN32
 #include "OpenSolomonsKey.h"
@@ -18,71 +16,56 @@ Ok, so we're gonna have to do audio on a separate thread anyways
 
 #include "gl_funcs.h"
 
-LARGE_INTEGER perf_last, perf_now = {};
-global LARGE_INTEGER perf_freq;
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////// TIMING
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+global LARGE_INTEGER g_performace_frequency;
+global LARGE_INTEGER g_perf_last, g_perf_now = {};
+struct Timer
+{
+    LARGE_INTEGER time_last;
+    
+    double get_elapsed_secs(b32 should_reset = false)
+    {
+        LARGE_INTEGER now;
+        float delta;
+        
+        QueryPerformanceCounter(&now);
+        
+        delta = g_performace_frequency.QuadPart != 0 
+            ? (float(now.QuadPart - time_last.QuadPart) * 1000.f) / g_performace_frequency.QuadPart
+            : 0.f;
+        
+        assert((delta >= 0.f));
+        
+        if (should_reset) time_last = now;
+        
+        return (delta / 1000.f);
+    }
+    
+    void reset(){QueryPerformanceCounter(&time_last);}
+};
 
-// NOTE(miked): Win32's DefWindowProc function takes the liberty of
-// blocking the whole thread whilst moving the window (via the title bar),
-// so we us these two bools to check for that, and NOT update.
-// Done using WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE
-global b32 is_currently_moving_or_resizing = false;
-global b32 was_previously_moving_or_resizing = false;
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////// CONTEXT CREATION
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // NOTE(miked): Thank you https://gist.github.com/nickrolfe/1127313ed1dbf80254b614a721b3ee9c
 // Modern Opengl is a bitch to init on Windows
 typedef HGLRC WINAPI wglCreateContextAttribsARB_type(HDC hdc, HGLRC hShareContext,const int *attribList);
-wglCreateContextAttribsARB_type *wglCreateContextAttribsARB;
-
 typedef const char* PFNwglGetExtensionsStringARB(HDC hdc);
-PFNwglGetExtensionsStringARB* wglGetExtensionsStringARB;
-
 typedef BOOL PFNwglSwapIntervalEXT(int interval);
+typedef BOOL WINAPI wglChoosePixelFormatARB_type(HDC hdc, const int *piAttribIList,const FLOAT *pfAttribFList, UINT nMaxFormats, int *piFormats, UINT *nNumFormats);
+
+wglCreateContextAttribsARB_type *wglCreateContextAttribsARB;
+PFNwglGetExtensionsStringARB* wglGetExtensionsStringARB;
 PFNwglSwapIntervalEXT* wglSwapIntervalEXT;
+wglChoosePixelFormatARB_type *wglChoosePixelFormatARB;
 
-b32 wgl_is_extension_supported(char* extname,  char* ext_string)
-{
-    char* csearch = extname;
-    char* chay = ext_string;
-    
-    while(*csearch && *chay)
-    {
-        if (!(*chay))
-        {
-            if (!(*csearch))
-                return false;
-            else 
-                return true;
-        }
-        
-        if (*csearch == *chay)
-        {
-            csearch++;
-        }
-        else
-            csearch = extname;
-        
-        chay++;
-    }
-    
-    if (!(*csearch) && !(*csearch))
-        return true;
-    else
-        return false;
-    
-}
-
-// See https://www.opengl.org/registry/specs/ARB/wgl_create_context.txt for all values
 #define WGL_CONTEXT_MAJOR_VERSION_ARB             0x2091
 #define WGL_CONTEXT_MINOR_VERSION_ARB             0x2092
 #define WGL_CONTEXT_PROFILE_MASK_ARB              0x9126
-
 #define WGL_CONTEXT_CORE_PROFILE_BIT_ARB          0x00000001
-
-typedef BOOL WINAPI wglChoosePixelFormatARB_type(HDC hdc, const int *piAttribIList,
-                                                 const FLOAT *pfAttribFList, UINT nMaxFormats, int *piFormats, UINT *nNumFormats);
-wglChoosePixelFormatARB_type *wglChoosePixelFormatARB;
-
-// See https://www.opengl.org/registry/specs/ARB/wgl_pixel_format.txt for all values
 #define WGL_DRAW_TO_WINDOW_ARB                    0x2001
 #define WGL_ACCELERATION_ARB                      0x2003
 #define WGL_SUPPORT_OPENGL_ARB                    0x2010
@@ -91,323 +74,38 @@ wglChoosePixelFormatARB_type *wglChoosePixelFormatARB;
 #define WGL_COLOR_BITS_ARB                        0x2014
 #define WGL_DEPTH_BITS_ARB                        0x2022
 #define WGL_STENCIL_BITS_ARB                      0x2023
-
 #define WGL_FULL_ACCELERATION_ARB                 0x2027
 #define WGL_TYPE_RGBA_ARB                         0x202B
 
-
-struct Timer
+b32 wgl_is_extension_supported(char* extname,  char* ext_string)
 {
-    LARGE_INTEGER time_last;
+    char* csearch = extname;
+    char* chay = ext_string;
     
-    double get_elapsed_secs(b32 should_reset = false)
+    while(*csearch && *chay)
     {
-        LARGE_INTEGER now;
-        QueryPerformanceCounter(&now);
-        i64 time_elapsed = now.QuadPart - time_last.QuadPart;
-        float delta;
-        if (perf_freq.QuadPart == 0) delta = 0;
-        else delta = (time_elapsed * 1000.f) / perf_freq.QuadPart;
-        assert((delta >= 0.f));
+        if (!(*chay)) return (!(*csearch));
         
-        if (should_reset) time_last = now;
+        if (*csearch == *chay) 
+            csearch++;
+        else
+            csearch = extname;
         
-        return (delta / 1000.f);
+        chay++;
     }
     
-    void reset()
-    {
-        QueryPerformanceCounter(&time_last);
-    }
-};
-
-#include <mmsystem.h> // WIN32_LEAN_AND_MEAN probably doesn't load this
-#include <dsound.h>
-
-global HWND     g_wind;
-global bool     g_running = true;
-global LPDIRECTSOUNDBUFFER g_secondary_buffer;
-/* Win32 AUDIO
-Uses DSound.
-*/
-
-#define DIRECT_SOUND_CREATE(name) HRESULT WINAPI name(LPGUID lpGuid, LPDIRECTSOUND* ppDS, LPUNKNOWN  pUnkOuter)
-typedef DIRECT_SOUND_CREATE(FNDirectSoundCreate);
-
-
-internal void win32_dsound_init()
-{
-    // load dsound
-    HMODULE dsound_lib = LoadLibraryA("dsound.dll");
-    fail_unless(dsound_lib, "dsound failed to load");
-    
-    FNDirectSoundCreate* dsound_create = (FNDirectSoundCreate*)GetProcAddress(dsound_lib, "DirectSoundCreate");
-    fail_unless(dsound_create, "");
-    
-    LPDIRECTSOUND dsound;
-    if (!SUCCEEDED(dsound_create(0, &dsound, 0))) _exit_with_message("dsound_create");
-    if (!SUCCEEDED(dsound->SetCooperativeLevel(g_wind, DSSCL_PRIORITY))) _exit_with_message("SetCooperativeLevel");
-    
-    WAVEFORMATEX wave_fmt = {};
-    wave_fmt.wFormatTag = WAVE_FORMAT_PCM;
-    wave_fmt.nChannels = AUDIO_CHANNELS;
-    wave_fmt.nSamplesPerSec = AUDIO_SAMPLERATE;
-    wave_fmt.wBitsPerSample = AUDIO_BPS;
-    wave_fmt.nBlockAlign = (wave_fmt.nChannels * wave_fmt.wBitsPerSample) / 8;
-    wave_fmt.nAvgBytesPerSec = wave_fmt.nSamplesPerSec * wave_fmt.nBlockAlign;
-    wave_fmt.cbSize = 0;
-    
-    LPDIRECTSOUNDBUFFER primary_buffer;
-    {
-        DSBUFFERDESC buffer_desc = {};
-        // create primary buffer
-        buffer_desc.dwFlags = DSBCAPS_PRIMARYBUFFER;
-        buffer_desc.dwSize = sizeof(DSBUFFERDESC);
-        
-        if (!SUCCEEDED(dsound->CreateSoundBuffer(&buffer_desc, &primary_buffer, 0)))
-            _exit_with_message("CreateSoundBuffer");
-        
-        if (!SUCCEEDED(primary_buffer->SetFormat(&wave_fmt))) _exit_with_message("SetFormat");
-    }
-    
-    // create secondary buffer
-    DSBUFFERDESC buffer_desc = {};
-    buffer_desc.dwSize = sizeof(buffer_desc);
-    buffer_desc.dwFlags = DSBCAPS_GLOBALFOCUS;
-    buffer_desc.dwBufferBytes = AUDIO_BUFFER_SIZE;
-    buffer_desc.lpwfxFormat = &wave_fmt;
-    if (!SUCCEEDED(dsound->CreateSoundBuffer(&buffer_desc, &g_secondary_buffer, 0)))
-        _exit_with_message("CreateSoundBuffer secondary");
-    
-    HRESULT err = g_secondary_buffer->Play(0, 0, DSBPLAY_LOOPING);
-}
-
-global u64 sample_counter = 0;
-
-internal void
-win32_dsound_get_bytes_to_output(DWORD* byte_to_lock, DWORD* bytes_to_write, float last_frame_delta)
-{
-    const float tdt = .0166f;
-    DWORD play_cursor, write_cursor;
-    if (!SUCCEEDED(g_secondary_buffer->GetCurrentPosition(&play_cursor, &write_cursor)))
-        _exit_with_message("GetCurrentPosition");
-    
-    DWORD expected_bytes_per_tick =(DWORD)( float(AUDIO_SAMPLERATE * AUDIO_BYTESPERSAMPLE) * tdt);
-    expected_bytes_per_tick -= expected_bytes_per_tick % AUDIO_BYTESPERSAMPLE;
-    
-    // x extra frames
-    DWORD safety_bytes = expected_bytes_per_tick * 5;
-    //safety_bytes -= safety_bytes % AUDIO_BYTESPERSAMPLE;
-    
-    DWORD expected_boundary = play_cursor + expected_bytes_per_tick;
-    
-    
-    DWORD safe_write_pos = write_cursor;
-    if (safe_write_pos < play_cursor)
-    {
-        // wrap it around
-        safe_write_pos += AUDIO_BUFFER_SIZE;
-    }
-    else safe_write_pos += safety_bytes;
-    
-    DWORD target_cursor;
-    if (safe_write_pos < expected_boundary)
-        target_cursor = expected_boundary + expected_bytes_per_tick;
-    else
-        target_cursor = write_cursor + expected_bytes_per_tick + safety_bytes;
-    
-    target_cursor %= AUDIO_BUFFER_SIZE;
-    
-    *byte_to_lock = (sample_counter * AUDIO_BYTESPERSAMPLE) % AUDIO_BUFFER_SIZE;
-    
-    if (*byte_to_lock > target_cursor)
-        *bytes_to_write = (AUDIO_BUFFER_SIZE -  *byte_to_lock) + target_cursor;
-    else
-        *bytes_to_write = target_cursor - *byte_to_lock;
+    return (!(*csearch) && !(*csearch));
     
 }
 
-internal void
-win32_dsound_copy_to_sound_buffer(DWORD byte_to_lock, DWORD bytes_to_write)
-{
-    
-    void* region1; DWORD region1_size;
-    void* region2; DWORD region2_size;
-    
-    if (bytes_to_write == 0) return;
-    
-    HRESULT error = g_secondary_buffer->Lock(
-        byte_to_lock, bytes_to_write,
-        &region1, &region1_size,
-        &region2, &region2_size, 0);
-    
-    assert(region1_size + region2_size == bytes_to_write);
-    assert(bytes_to_write <= AUDIO_BUFFER_SIZE);
-    if (!SUCCEEDED(error))
-    {
-        printf(" \t%d %d\n %x\n", byte_to_lock, bytes_to_write,  error);
-        _exit_with_message("Lock failed");
-    }
-    
-    DWORD region1_samples = region1_size / AUDIO_BYTESPERSAMPLE;
-    DWORD region2_samples = region2_size / AUDIO_BYTESPERSAMPLE;
-    
-    i16* sample_in = (i16*)g_audio.buffer;
-    i16* sample_out = (i16*) region1;
-    for (DWORD sample_idx = 0; sample_idx < region1_samples; sample_idx++)
-    {
-        *sample_out++ = *sample_in++;
-        *sample_out++ = *sample_in++;
-        sample_counter++;
-    }
-    
-    sample_out = (i16*) region2;
-    for (DWORD sample_idx = 0; sample_idx < region2_samples; sample_idx++)
-    {
-        *sample_out++ = *sample_in++;
-        *sample_out++ = *sample_in++;
-        sample_counter++;
-    }
-    
-    fail_unless(SUCCEEDED(g_secondary_buffer->Unlock(
-        region1, region1_size,
-        region2, region2_size)), "");
-}
-
-internal void
-win32_update_and_render(HDC dc)
-{
-    
-    QueryPerformanceCounter(&perf_now);
-    i64 time_elapsed = perf_now.QuadPart - perf_last.QuadPart;
-    float delta;
-    if (perf_freq.QuadPart == 0) delta = 0;
-    else delta = ((float)time_elapsed) / (float)perf_freq.QuadPart;
-    //assert(delta >= 0);
-    
-    if (was_previously_moving_or_resizing &&
-        !is_currently_moving_or_resizing)
-    {
-        delta = 0.f;
-        was_previously_moving_or_resizing = false;
-    }
-    //fprintf(stdout, "ms : %f\n", delta);
-    //delta /= 1000.f;
-    
-    if (delta >= 0.9f) delta = 0.9f;
-    
-    DWORD byte_to_lock, bytes_to_write;
-    win32_dsound_get_bytes_to_output(&byte_to_lock, &bytes_to_write, delta);
-    u64 samples_to_write = bytes_to_write / AUDIO_BYTESPERSAMPLE;
-    
-    cb_render(g_input_state, samples_to_write, delta);
-    
-    win32_dsound_copy_to_sound_buffer(byte_to_lock, bytes_to_write);
-    
-    perf_last = perf_now;
-    SwapBuffers(dc);
-}
-
-
-internal LRESULT CALLBACK
-win32_windproc(
-_In_ HWND   hwnd,
-_In_ UINT   msg,
-_In_ WPARAM wparam,
-_In_ LPARAM lparam)
-{
-    LRESULT result = 0;
-    
-    switch(msg)
-    {
-        case WM_DESTROY:
-        {
-            PostQuitMessage(0);
-            g_running = false;
-        }break;
-        
-        case WM_PAINT:
-        {
-            PAINTSTRUCT ps;
-            BeginPaint(hwnd, &ps);
-            EndPaint(hwnd, &ps);
-        } break;
-        
-        case WM_SIZE:
-        {
-            g_wind_width = LOWORD(lparam);
-            g_wind_height =  HIWORD(lparam);
-            glViewport(0,0,g_wind_width, g_wind_height);
-            
-            cb_resize();
-            
-            OutputDebugStringA("WM_SIZE\n");
-            PostMessage(hwnd, WM_PAINT, 0, 0);
-        } break;
-        
-        // NOTE(miked): For the blocking of moving a window bug, does not
-        // happen on X11
-        case WM_ENTERSIZEMOVE:
-        {
-            was_previously_moving_or_resizing = is_currently_moving_or_resizing;
-            is_currently_moving_or_resizing = true;
-        } break;
-        case WM_EXITSIZEMOVE:
-        {
-            was_previously_moving_or_resizing = is_currently_moving_or_resizing;
-            is_currently_moving_or_resizing = false;
-        } break;
-        
-        default:
-        {
-            result = DefWindowProc(hwnd, msg, wparam, lparam);
-        } break;
-    }
-    return result;
-}
-
-internal void
-win32_init(HINSTANCE hInstance)
-{
-    // create the actual window
-    WNDCLASSA window_class = {
-        .style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
-        .lpfnWndProc = win32_windproc,
-        .hInstance = hInstance,
-        .hCursor = LoadCursor(0, IDC_ARROW),
-        .hbrBackground = 0,
-        .lpszClassName = OSK_CLASS_NAME,
-    };
-    fail_unless(RegisterClassA(&window_class), "Failed to register class");
-    
-    RECT rect = {
-        .right = 1024,
-        .bottom = 896
-    };
-    // DWORD window_style = WS_OVERLAPPEDWINDOW ^ WS_THICKFRAME;
-    DWORD window_style = WS_OVERLAPPEDWINDOW;
-    AdjustWindowRect(&rect, window_style, false);
-    
-    g_wind = CreateWindowExA(
-        0,
-        OSK_CLASS_NAME,
-        "Solomon's Key",
-        window_style,
-        CW_USEDEFAULT, CW_USEDEFAULT,
-        rect.right - rect.left,
-        rect.bottom - rect.top,
-        0, 0, hInstance, 0);
-    fail_unless(g_wind, "Failed to create window");
-}
-
+// Before we can load extensions, we need a dummy OpenGL context, created using a dummy window.
+// We use a dummy window because you can only set the pixel format for a window once. For the
+// real window, we want to use wglChoosePixelFormatARB (so we can potentially specify options
+// that aren't available in PIXELFORMATDESCRIPTOR), but we can't load and use that before we
+// have a context.
 internal void
 win32_init_gl_extensions()
 {
-    // Before we can load extensions, we need a dummy OpenGL context, created using a dummy window.
-    // We use a dummy window because you can only set the pixel format for a window once. For the
-    // real window, we want to use wglChoosePixelFormatARB (so we can potentially specify options
-    // that aren't available in PIXELFORMATDESCRIPTOR), but we can't load and use that before we
-    // have a context.
     WNDCLASSA window_class = {
         .style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
         .lpfnWndProc = DefWindowProcA,
@@ -415,31 +113,26 @@ win32_init_gl_extensions()
         .lpszClassName = "Dummy_WGL_djuasiodwa",
     };
     
-    if (!RegisterClassA(&window_class)) {
+    if (!RegisterClassA(&window_class)) 
         inform("Failed to register dummy OpenGL window.");
-    }
     
     HWND dummy_window = CreateWindowExA(
         0,
         window_class.lpszClassName,
         "Dummy OpenGL Window",
         0,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        0,
-        0,
+        CW_USEDEFAULT,CW_USEDEFAULT,CW_USEDEFAULT,CW_USEDEFAULT,
+        0,0,
         window_class.hInstance,
         0);
     
-    if (!dummy_window) {
+    if (!dummy_window) 
         inform("Failed to create dummy OpenGL window.");
-    }
     
     HDC dummy_dc = GetDC(dummy_window);
     
-    PIXELFORMATDESCRIPTOR pfd = {
+    PIXELFORMATDESCRIPTOR pfd = 
+    {
         .nSize = sizeof(pfd),
         .nVersion = 1,
         .dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
@@ -452,59 +145,40 @@ win32_init_gl_extensions()
     };
     
     int pixel_format = ChoosePixelFormat(dummy_dc, &pfd);
-    if (!pixel_format) {
+    if (!pixel_format) 
         inform("Failed to find a suitable pixel format.");
-    }
-    if (!SetPixelFormat(dummy_dc, pixel_format, &pfd)) {
+    
+    if (!SetPixelFormat(dummy_dc, pixel_format, &pfd)) 
         inform("Failed to set the pixel format.");
-    }
     
     HGLRC dummy_context = wglCreateContext(dummy_dc);
-    if (!dummy_context) {
+    if (!dummy_context) 
         inform("Failed to create a dummy OpenGL rendering context.");
-    }
     
-    if (!wglMakeCurrent(dummy_dc, dummy_context)) {
+    if (!wglMakeCurrent(dummy_dc, dummy_context)) 
         inform("Failed to activate dummy OpenGL rendering context.");
-    }
     
-    wglCreateContextAttribsARB = (wglCreateContextAttribsARB_type*)wglGetProcAddress(
-        "wglCreateContextAttribsARB");
-    wglChoosePixelFormatARB = (wglChoosePixelFormatARB_type*)wglGetProcAddress(
-        "wglChoosePixelFormatARB");
-    wglGetExtensionsStringARB = (PFNwglGetExtensionsStringARB*)wglGetProcAddress(
-        "wglGetExtensionsStringARB");
+    wglCreateContextAttribsARB = (wglCreateContextAttribsARB_type*)wglGetProcAddress("wglCreateContextAttribsARB");
+    wglChoosePixelFormatARB = (wglChoosePixelFormatARB_type*)wglGetProcAddress("wglChoosePixelFormatARB");
+    wglGetExtensionsStringARB = (PFNwglGetExtensionsStringARB*)wglGetProcAddress("wglGetExtensionsStringARB");
     
     if (wglGetExtensionsStringARB)
     {
         char* ext_string = (char*)wglGetExtensionsStringARB(dummy_dc);
-        
         printf("WGL extensions: %s\n", ext_string);
-        
         
         if (wgl_is_extension_supported("WGL_EXT_swap_control", ext_string))
         {
             inform("wglSwapInterval is supported!");
-            
-            wglSwapIntervalEXT = (PFNwglSwapIntervalEXT*)wglGetProcAddress(
-                "wglSwapIntervalEXT");
+            wglSwapIntervalEXT = (PFNwglSwapIntervalEXT*)wglGetProcAddress("wglSwapIntervalEXT");
             
         }
     }
     
-    
-    
     wglMakeCurrent(dummy_dc, 0);
     wglDeleteContext(dummy_context);
-    
-    
-    
-    
-    
     ReleaseDC(dummy_window, dummy_dc);
     DestroyWindow(dummy_window);
-    
-    
     
 }
 
@@ -564,13 +238,338 @@ win32_init_gl(HDC real_dc)
 }
 
 
-b32 win32_get_key_state(i32 key)
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////// AUDIO
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#include <mmsystem.h> // WIN32_LEAN_AND_MEAN probably doesn't load this
+#include <dsound.h>
+global LPDIRECTSOUNDBUFFER g_secondary_buffer;
+global u64 g_sample_counter = 0;
+HANDLE g_dsound_sem;
+
+// Function defs we *need* from audio.cpp
+internal void audio_update(const InputState* const istate, u64 samples_to_write);
+internal void audio_update_all_sounds();
+internal DWORD dsound_cb_audio(void *unused);
+
+#define DIRECT_SOUND_CREATE(name) HRESULT WINAPI name(LPGUID lpGuid, LPDIRECTSOUND* ppDS, LPUNKNOWN  pUnkOuter)
+typedef DIRECT_SOUND_CREATE(FNDirectSoundCreate);
+
+internal void win32_dsound_init(HWND window_handle)
 {
-    return GetAsyncKeyState(key);
+    // load dsound
+    HMODULE dsound_lib = LoadLibraryA("dsound.dll");
+    fail_unless(dsound_lib, "dsound failed to load");
+    
+    FNDirectSoundCreate* dsound_create = (FNDirectSoundCreate*)GetProcAddress(dsound_lib, "DirectSoundCreate");
+    fail_unless(dsound_create, "");
+    
+    // Create the dsound object
+    LPDIRECTSOUND dsound;
+    if (!SUCCEEDED(dsound_create(0, &dsound, 0))) _exit_with_message("dsound_create");
+    if (!SUCCEEDED(dsound->SetCooperativeLevel(window_handle, DSSCL_PRIORITY))) _exit_with_message("SetCooperativeLevel");
+    
+    WAVEFORMATEX wave_fmt = {};
+    wave_fmt.wFormatTag = WAVE_FORMAT_PCM;
+    wave_fmt.nChannels = AUDIO_CHANNELS;
+    wave_fmt.nSamplesPerSec = AUDIO_SAMPLERATE;
+    wave_fmt.wBitsPerSample = AUDIO_BPS;
+    wave_fmt.nBlockAlign = (wave_fmt.nChannels * wave_fmt.wBitsPerSample) / 8;
+    wave_fmt.nAvgBytesPerSec = wave_fmt.nSamplesPerSec * wave_fmt.nBlockAlign;
+    wave_fmt.cbSize = 0;
+    
+    LPDIRECTSOUNDBUFFER primary_buffer;
+    {
+        // create primary buffer; It's useless but we have to
+        DSBUFFERDESC buffer_desc = {};
+        buffer_desc.dwFlags = DSBCAPS_PRIMARYBUFFER;
+        buffer_desc.dwSize = sizeof(DSBUFFERDESC);
+        
+        if (!SUCCEEDED(dsound->CreateSoundBuffer(&buffer_desc, &primary_buffer, 0)))
+            _exit_with_message("CreateSoundBuffer");
+        
+        if (!SUCCEEDED(primary_buffer->SetFormat(&wave_fmt))) _exit_with_message("SetFormat");
+    }
+    
+    // create secondary buffer (we're using this one)
+    DSBUFFERDESC buffer_desc = {};
+    buffer_desc.dwSize = sizeof(buffer_desc);
+    buffer_desc.dwFlags = DSBCAPS_GLOBALFOCUS;
+    buffer_desc.dwBufferBytes = AUDIO_BUFFER_SIZE;
+    buffer_desc.lpwfxFormat = &wave_fmt;
+    if (!SUCCEEDED(dsound->CreateSoundBuffer(&buffer_desc, &g_secondary_buffer, 0)))
+        _exit_with_message("CreateSoundBuffer secondary");
+    
+    // Start playing right away
+    HRESULT err = g_secondary_buffer->Play(0, 0, DSBPLAY_LOOPING);
+    
+    DWORD audio_thread_id;
+    HANDLE audio_thread = CreateThread(
+        0,0, 
+        dsound_cb_audio,
+        0,
+        0,
+        &audio_thread_id);
+    
+    g_dsound_sem = CreateSemaphoreA(0,0,1,0);
+    
 }
 
 internal void
-win32_update_all_keys()
+win32_dsound_get_bytes_to_output(DWORD* byte_to_lock, DWORD* bytes_to_write)
+{
+    const float target_framerate = .0166f;
+    DWORD play_cursor, write_cursor;
+    if (!SUCCEEDED(g_secondary_buffer->GetCurrentPosition(&play_cursor, &write_cursor)))
+        _exit_with_message("GetCurrentPosition failed!");
+    
+    // how many bytes _should_ be written
+    DWORD expected_bytes_per_tick =(DWORD)( float(AUDIO_SAMPLERATE * AUDIO_BYTESPERSAMPLE) * target_framerate);
+    expected_bytes_per_tick -= expected_bytes_per_tick % AUDIO_BYTESPERSAMPLE;
+    
+    // number of extra bytes to write, if we delay a bit
+    DWORD safety_bytes = expected_bytes_per_tick * 5;
+    
+    // where the play cursor is gonna be
+    DWORD expected_boundary = play_cursor + expected_bytes_per_tick;
+    
+    DWORD safe_write_pos = write_cursor;
+    if (safe_write_pos < play_cursor)
+        safe_write_pos += AUDIO_BUFFER_SIZE; // wrap it around if we're past the write_cursor
+    else safe_write_pos += safety_bytes;
+    // now we know where to write _to_
+    
+    DWORD target_cursor;
+    if (safe_write_pos < expected_boundary)
+        target_cursor = expected_boundary + expected_bytes_per_tick;
+    else
+        target_cursor = write_cursor + expected_bytes_per_tick + safety_bytes;
+    
+    target_cursor %= AUDIO_BUFFER_SIZE;
+    *byte_to_lock = (g_sample_counter * AUDIO_BYTESPERSAMPLE) % AUDIO_BUFFER_SIZE;
+    
+    if (*byte_to_lock > target_cursor)
+        *bytes_to_write = (AUDIO_BUFFER_SIZE -  *byte_to_lock) + target_cursor;
+    else
+        *bytes_to_write = target_cursor - *byte_to_lock;
+    
+}
+
+internal void win32_dsound_copy_to_sound_buffer(DWORD byte_to_lock, DWORD bytes_to_write)
+{
+    
+    void* region1; DWORD region1_size;
+    void* region2; DWORD region2_size;
+    
+    if (bytes_to_write == 0) return;
+    
+    HRESULT error = g_secondary_buffer->Lock(
+        byte_to_lock, bytes_to_write,
+        &region1, &region1_size,
+        &region2, &region2_size, 0);
+    
+    assert(region1_size + region2_size == bytes_to_write);
+    assert(bytes_to_write <= AUDIO_BUFFER_SIZE);
+    if (!SUCCEEDED(error))
+    {
+        printf(" \t%d %d\n %x\n", byte_to_lock, bytes_to_write,  error);
+        _exit_with_message("Lock failed");
+    }
+    
+    DWORD region1_samples = region1_size / AUDIO_BYTESPERSAMPLE;
+    DWORD region2_samples = region2_size / AUDIO_BYTESPERSAMPLE;
+    
+    i16* sample_in = (i16*)g_audio.buffer;
+    i16* sample_out = (i16*) region1;
+    for (DWORD sample_idx = 0; sample_idx < region1_samples; sample_idx++)
+    {
+        *sample_out++ = *sample_in++;
+        *sample_out++ = *sample_in++;
+        g_sample_counter++;
+    }
+    
+    sample_out = (i16*) region2;
+    for (DWORD sample_idx = 0; sample_idx < region2_samples; sample_idx++)
+    {
+        *sample_out++ = *sample_in++;
+        *sample_out++ = *sample_in++;
+        g_sample_counter++;
+    }
+    
+    fail_unless(SUCCEEDED(g_secondary_buffer->Unlock(
+        region1, region1_size,
+        region2, region2_size)), "");
+}
+
+internal DWORD dsound_cb_audio(void *unused)
+{
+    
+    i16 *buffer = (i16*)g_audio.buffer;
+    
+    for(;;)
+    {
+        DWORD byte_to_lock, bytes_to_write;
+        win32_dsound_get_bytes_to_output(&byte_to_lock, &bytes_to_write);
+        
+        u64 samples_to_write = bytes_to_write / AUDIO_BYTESPERSAMPLE;
+        if (samples_to_write > 0)
+        {
+            
+            audio_update_all_sounds();
+            audio_update(0, samples_to_write);
+            
+            win32_dsound_copy_to_sound_buffer(byte_to_lock, bytes_to_write);
+            
+        }
+        else
+        {
+            // Wait for our target framerate in ms
+            WaitForSingleObjectEx(g_dsound_sem, u64(0.0166f * 1000), FALSE);
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////// WINDOWING
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// NOTE(miked): Win32's DefWindowProc function takes the liberty of
+// blocking the whole thread whilst moving the window (via the title bar),
+// so we us these two bools to check for that, and NOT update.
+// Done using WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE
+global b32 is_currently_moving_or_resizing = false;
+global b32 was_previously_moving_or_resizing = false;
+
+global HWND     g_wind;
+global bool     g_running = true;
+
+Timer g_window_timer;
+
+internal void win32_update_and_render(HDC dc)
+{
+    float delta_time = g_window_timer.get_elapsed_secs(true);
+    
+    if (was_previously_moving_or_resizing &&
+        !is_currently_moving_or_resizing)
+    {
+        delta_time = 0.f;
+        was_previously_moving_or_resizing = false;
+    }
+    
+    if (delta_time >= 0.9f) delta_time = 0.9f;
+    
+    //audio_update_all_sounds();
+    //audio_update(&g_input_state, samples_to_write);
+    
+    cb_render(g_input_state, 0, delta_time);
+    
+    // Wake up the audio thread if something needs to be written _now_
+    {
+        DWORD byte_to_lock, bytes_to_write;
+        win32_dsound_get_bytes_to_output(&byte_to_lock, &bytes_to_write);
+        
+        u64 samples_to_write = bytes_to_write / AUDIO_BYTESPERSAMPLE;
+        if (samples_to_write > 0)
+            ReleaseSemaphore(g_dsound_sem, 1, 0);
+    }
+    
+    SwapBuffers(dc);
+}
+
+
+internal LRESULT CALLBACK
+win32_windproc(
+_In_ HWND   hwnd,
+_In_ UINT   msg,
+_In_ WPARAM wparam,
+_In_ LPARAM lparam)
+{
+    LRESULT result = 0;
+    
+    switch(msg)
+    {
+        case WM_DESTROY:
+        {
+            PostQuitMessage(0);
+            g_running = false;
+        }break;
+        
+        case WM_PAINT:
+        {
+            PAINTSTRUCT ps;
+            BeginPaint(hwnd, &ps);
+            EndPaint(hwnd, &ps);
+        } break;
+        
+        case WM_SIZE:
+        {
+            g_wind_width = LOWORD(lparam);
+            g_wind_height =  HIWORD(lparam);
+            glViewport(0,0,g_wind_width, g_wind_height);
+            
+            cb_resize();
+            
+            OutputDebugStringA("WM_SIZE\n");
+            PostMessage(hwnd, WM_PAINT, 0, 0);
+        } break;
+        
+        case WM_ENTERSIZEMOVE:
+        case WM_EXITSIZEMOVE:
+        {
+            
+            was_previously_moving_or_resizing = is_currently_moving_or_resizing;
+            is_currently_moving_or_resizing = msg == WM_ENTERSIZEMOVE;
+        } break;
+        
+        default:
+        {
+            result = DefWindowProc(hwnd, msg, wparam, lparam);
+        } break;
+    }
+    return result;
+}
+
+internal void
+win32_init(HINSTANCE hInstance)
+{
+    // create the actual window
+    WNDCLASSA window_class = {
+        .style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
+        .lpfnWndProc = win32_windproc,
+        .hInstance = hInstance,
+        .hCursor = LoadCursor(0, IDC_ARROW),
+        .hbrBackground = 0,
+        .lpszClassName = OSK_CLASS_NAME,
+    };
+    fail_unless(RegisterClassA(&window_class), "Failed to register class");
+    
+    RECT rect = 
+    {
+        .right = 1024,
+        .bottom = 896
+    };
+    // DWORD window_style = WS_OVERLAPPEDWINDOW ^ WS_THICKFRAME;
+    DWORD window_style = WS_OVERLAPPEDWINDOW;
+    AdjustWindowRect(&rect, window_style, false);
+    
+    g_wind = CreateWindowExA(
+        0,
+        OSK_CLASS_NAME,
+        "Solomon's Key",
+        window_style,
+        CW_USEDEFAULT, CW_USEDEFAULT,
+        rect.right - rect.left,
+        rect.bottom - rect.top,
+        0, 0, hInstance, 0);
+    fail_unless(g_wind, "Failed to create window");
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////// INPUT
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+b32 win32_get_key_state(i32 key) {return GetAsyncKeyState(key);}
+
+// Auto-generate the list of keys to update
+internal void win32_update_all_keys()
 {
 #define KEYDOWN(name, _X, keysym) g_input_state.name = win32_get_key_state(keysym);
 #define KEYPRESS(name, _X, keysym) { \
@@ -586,62 +585,6 @@ win32_update_all_keys()
 #undef KEYPRESS
 }
 
-// THREADING
-
-const u32 MAX_THREADS = 3;
-global HANDLE win32_threads[MAX_THREADS];
-
-struct win32_ThreadInfo
-{
-    u32 thread_index;
-};
-
-struct win32_WorkQueueEntry
-{
-    char* string_to_print;
-};
-
-
-#include <intrin.h>
-
-#define COMPLETE_PAST_WRITES _WriteBarrier(); _mm_sfence()
-#define COMPLETE_PAST_READS  _ReadBarrier()
-
-global u32 volatile next_entry;
-global u32 volatile entry_count;
-global win32_WorkQueueEntry entries[256];
-
-internal void push_queue_entry(char* string)
-{
-    win32_WorkQueueEntry* entry = entries + entry_count;
-    entry->string_to_print = string;
-    
-    COMPLETE_PAST_WRITES;
-    
-    entry_count++;
-    
-}
-
-DWORD test_thread_proc(void* params)
-{
-    win32_ThreadInfo* info = (win32_ThreadInfo*)params;
-    
-    while (1)
-    {
-        if (next_entry < entry_count)
-        {
-            int next_entry_index =  InterlockedIncrement(&next_entry) - 1;
-            
-            COMPLETE_PAST_READS;
-            
-            win32_WorkQueueEntry* entry = entries + next_entry_index;
-            
-            inform("THREAD %d: %s", info->thread_index, entry->string_to_print);
-        }
-    }
-    
-}
-
 
 int WinMain(
 HINSTANCE hInstance,
@@ -649,43 +592,12 @@ HINSTANCE hPrevInstance,
 LPSTR     lpCmdLine,
 int       nShowCmd)
 {
-    MSG message;
     
-#if 1
+#if 0
     AllocConsole() ;
     AttachConsole( GetCurrentProcessId() ) ;
     freopen( "CON", "w", stdout ) ;
 #endif
-    
-    
-#if 0    
-    win32_ThreadInfo info[MAX_THREADS] = {};
-    for (i32 i = 0; i < MAX_THREADS; ++i)
-    {
-        info[i].thread_index = i;
-        
-        DWORD thread_id;
-        HANDLE thread_handle = CreateThread(
-            0,0, 
-            test_thread_proc,
-            info + i,
-            0,
-            &thread_id);
-    }
-    
-    push_queue_entry("String 0\n");
-    push_queue_entry("String 1\n");
-    push_queue_entry("String 2\n");
-    push_queue_entry("String 3\n");
-    push_queue_entry("String 4\n");
-    push_queue_entry("String 5\n");
-    push_queue_entry("String 6\n");
-    push_queue_entry("String 7\n");
-    push_queue_entry("String 8\n");
-    push_queue_entry("String 9\n");
-#endif
-    
-    
     
     win32_init(hInstance);
     HDC dc = GetDC(g_wind);
@@ -693,18 +605,17 @@ int       nShowCmd)
     win32_init_gl(dc);
     cb_init();
     
-    win32_dsound_init();
-    
-    OutputDebugStringA("Initialized Opengl");
+    win32_dsound_init(g_wind);
     
     ShowWindow(g_wind, SW_SHOW);
     UpdateWindow(g_wind);
     
-    QueryPerformanceFrequency(&perf_freq);
-    QueryPerformanceCounter(&perf_last);
+    QueryPerformanceFrequency(&g_performace_frequency);
     
+    g_window_timer.reset();
     while (g_running)
     {
+        MSG message;
         while (PeekMessage(&message, g_wind, 0, 0, PM_REMOVE))
         {
             TranslateMessage(&message);
@@ -715,8 +626,6 @@ int       nShowCmd)
         win32_update_and_render(dc);
         
     }
-    
-    //system("pause");
     
     return 0;
 }

--- a/src/x11_OpenSolomonsKey.cpp
+++ b/src/x11_OpenSolomonsKey.cpp
@@ -86,9 +86,6 @@ global pthread_t g_audiothread;
 internal void audio_update(const InputState* const istate, u64 samples_to_write);
 internal void audio_update_all_sounds();
 
-#define OSK_LOCK_AUDIO sem_wait(&g_audiosem)
-#define OSK_UNLOCK_AUDIO sem_post(&g_audiosem)
-
 void* alsa_cb_audio(void* unused)
 {
     


### PR DESCRIPTION
Both platforms now support audio that doesn't block when the main thread does. This is mainly needed on Windows, since moving or resizing the window *will* block the main thread.